### PR TITLE
V0.7 lqr objective bugfix

### DIFF
--- a/src/objective.jl
+++ b/src/objective.jl
@@ -153,7 +153,7 @@ function LQRObjective(Q::AbstractArray, R::AbstractArray, Qf::AbstractArray,
     cf = 0.5*xf'*Qf*xf
 
     ℓ = QuadraticCost(Q, R, H, q, r, c, checks=checks)
-    ℓN = QuadraticCost(Qf, R, H, q, r, cf, checks=false, terminal=true)
+    ℓN = QuadraticCost(Qf, R, H, qf, r, cf, checks=false, terminal=true)
 
     Objective(ℓ, ℓN, N)
 end

--- a/test/objective_tests.jl
+++ b/test/objective_tests.jl
@@ -91,6 +91,9 @@ using TrajectoryOptimization: state, control
         @test obj[2].r ≈ zero(r)
         @test obj[2].c ≈ 0.5 * xf'Q * xf
         @test obj[end].c ≈ 0.5 * xf'Qf * xf
+        @test obj[end].q ≈ -Qf * xf
+        @test obj[end].Q ≈ Qf
+        @test obj[end].R ≈ R
 
         obj = LQRObjective(Matrix(Q), R, Qf, xf, N)
         @test eltype(obj) <: QuadraticCost{n,m,Float64,<:SizedMatrix,<:Diagonal}
@@ -99,6 +102,9 @@ using TrajectoryOptimization: state, control
         @test obj[2].r ≈ zero(r)
         @test obj[2].c ≈ 0.5 * xf'Q * xf
         @test obj[end].c ≈ 0.5 * xf'Qf * xf
+        @test obj[end].q ≈ -Qf * xf
+        @test obj[end].Q ≈ Qf
+        @test obj[end].R ≈ R
 
         obj = LQRObjective(Q.diag, R.diag, Qf, xf, N)
         @test eltype(obj) <: DiagonalCost{n,m}
@@ -107,6 +113,9 @@ using TrajectoryOptimization: state, control
         @test obj[2].r ≈ zero(r)
         @test obj[2].c ≈ 0.5 * xf'Q * xf
         @test obj[end].c ≈ 0.5 * xf'Qf * xf
+        @test obj[end].q ≈ -Qf * xf
+        @test obj[end].Q ≈ Qf
+        @test obj[end].R ≈ R
 
         obj = LQRObjective(Diagonal(Vector(Q.diag)), R.diag, Vector(Qf.diag), xf, N)
         @test eltype(obj) <: DiagonalCost{n,m}


### PR DESCRIPTION
Resolves #66 by using `qf` for final cost. Adds tests that catch original error and pass with fix.